### PR TITLE
add utf8 encoding

### DIFF
--- a/lib/wire.js
+++ b/lib/wire.js
@@ -217,7 +217,7 @@ Wire.prototype._onDone = function(metadata) {
         this._fail();
         return false;
     }
-    this.emit('metadata', {info: bencode.decode(metadata)}, this._infohash);
+    this.emit('metadata', {info: bencode.decode(metadata, 'utf8')}, this._infohash);
 };
 
 Wire.prototype._fail = function() {


### PR DESCRIPTION
avoids buffers in resulting object.
